### PR TITLE
Remove unnecessary output class name limitation

### DIFF
--- a/RibbonTools/Build/AbstractCodeBuilder.cs
+++ b/RibbonTools/Build/AbstractCodeBuilder.cs
@@ -48,17 +48,7 @@ namespace UIRibbonTools
             {
                 string directory = Path.GetDirectoryName(path);
 
-                string xmlFileName = Path.GetFileNameWithoutExtension(path);
-                char last = xmlFileName[xmlFileName.Length - 1];
-                if (Char.IsNumber(last))
-                {
-                    ribbonItemsClass = RibbonItems + last.ToString();
-                }
-                else
-                {
-                    ribbonItemsClass = RibbonItems;
-                }
-
+                ribbonItemsClass = Path.GetFileNameWithoutExtension(path);
 
                 RibbonParser.ParseResult results = parser.Results;
 #if OldCode


### PR DESCRIPTION
Classes can be generated with whatever name you want. The class name (and output file name) is determined by the Filename of the XML file (without it's extension).

This removes an arbritrary limitation that the output class name must be RibbonItems (a singular number at the end, like `TestThing1.xml` will create the class `RibbonItems1`)

This resolves issue #18 

I've confirmed that this PR works with my own project which (now) has more than 10 Ribbons, all in different projects, which is now possible instead of mucking around with the Modes to go around this limitation.